### PR TITLE
Allows to encode empty tables as arrays.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ notes
 packages
 tags
 tests/utf8.dat
+*.vcproj
+*.sln
+CMakeCache.txt
+CMakeFiles/*
+cjson.def
+cjson.exp
+*.dll*
+cmake_install.cmake

--- a/fpconv.c
+++ b/fpconv.c
@@ -35,6 +35,10 @@
 
 #include "fpconv.h"
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 /* Lua CJSON assumes the locale is the same for all threads within a
  * process and doesn't change after initialisation.
  *
@@ -124,7 +128,7 @@ double fpconv_strtod(const char *nptr, char **endptr)
     /* Duplicate number into buffer */
     if (buflen >= FPCONV_G_FMT_BUFSIZE) {
         /* Handle unusually large numbers */
-        buf = malloc(buflen + 1);
+        buf = (char *)malloc(buflen + 1);
         if (!buf) {
             fprintf(stderr, "Out of memory");
             abort();
@@ -196,10 +200,12 @@ int fpconv_g_fmt(char *str, double num, int precision)
     return len;
 }
 
+#ifndef USE_INTERNAL_FPCONV
 void fpconv_init()
 {
     fpconv_update_locale();
 }
+#endif
 
 /* vi:ai et sw=4 ts=4:
  */

--- a/fpconv.h
+++ b/fpconv.h
@@ -6,6 +6,10 @@
  * -1.7976931348623e+308 */
 # define FPCONV_G_FMT_BUFSIZE   32
 
+#ifdef _MSC_VER
+#define inline 
+#endif
+
 #ifdef USE_INTERNAL_FPCONV
 static inline void fpconv_init()
 {

--- a/lua-cjson-git-1.rockspec
+++ b/lua-cjson-git-1.rockspec
@@ -1,0 +1,62 @@
+package = "lua-cjson"
+version = "git-1"
+
+description = {
+    summary = "A fast JSON encoding/parsing module",
+    detailed = [[
+        The Lua CJSON module provides JSON support for Lua. It features:
+        - Fast, standards compliant encoding/parsing routines
+        - Full support for JSON with UTF-8, including decoding surrogate pairs
+        - Optional run-time support for common exceptions to the JSON specification
+          (infinity, NaN,..)
+        - No dependencies on other libraries
+    ]],
+    homepage = "http://www.kyne.com.au/~mark/software/lua-cjson.php",
+    license = "MIT"
+}
+
+source = {
+    url = "https://git.inconcert/lua-libraries/lua-cjson",
+    dir = "lua-cjson"
+}
+
+dependencies = {
+    "lua >= 5.1"
+}
+
+build = {
+    type = "builtin",
+    modules = {
+        cjson = {
+            defines = { "MULTIPLE_THREADS" },
+            sources = { "lua_cjson.c", "strbuf.c", "fpconv.c" },
+            defines = {
+-- LuaRocks does not support platform specific configuration for Solaris.
+-- Uncomment the line below on Solaris platforms if required.
+--                "USE_INTERNAL_ISINF"
+            }
+        }
+    },
+    install = {
+        lua = {
+            ["cjson.util"] = "lua/cjson/util.lua"
+        },
+        bin = {
+            json2lua = "lua/json2lua.lua",
+            lua2json = "lua/lua2json.lua"
+        }
+    },
+    -- Override default build options (per platform)
+    platforms = {
+        win32 = { modules = { cjson = { defines = {
+            "MULTIPLE_THREADS", "DISABLE_INVALID_NUMBERS"
+        } } } }
+    },
+    copy_directories = { "tests" }
+}
+
+-- Para compilar lua-cjson en windows:
+-- luarocks make CFLAGS="/TP /MD /O2 -DMULTIPLE_THREADS -DUSE_INTERNAL_FPCONV"
+
+
+-- vi:ai et sw=4 ts=4:

--- a/strbuf.c
+++ b/strbuf.c
@@ -58,7 +58,7 @@ void strbuf_init(strbuf_t *s, int len)
     s->reallocs = 0;
     s->debug = 0;
 
-    s->buf = malloc(size);
+    s->buf = (char *)malloc(size);
     if (!s->buf)
         die("Out of memory");
 
@@ -69,7 +69,7 @@ strbuf_t *strbuf_new(int len)
 {
     strbuf_t *s;
 
-    s = malloc(sizeof(strbuf_t));
+    s = (strbuf_t *)malloc(sizeof(strbuf_t));
     if (!s)
         die("Out of memory");
 
@@ -173,7 +173,7 @@ void strbuf_resize(strbuf_t *s, int len)
     }
 
     s->size = newsize;
-    s->buf = realloc(s->buf, s->size);
+    s->buf = (char *)realloc(s->buf, s->size);
     if (!s->buf)
         die("Out of memory");
     s->reallocs++;
@@ -221,12 +221,12 @@ void strbuf_append_fmt(strbuf_t *s, int len, const char *fmt, ...)
 void strbuf_append_fmt_retry(strbuf_t *s, const char *fmt, ...)
 {
     va_list arg;
-    int fmt_len, try;
+    int fmt_len, attempt;
     int empty_len;
 
     /* If the first attempt to append fails, resize the buffer appropriately
      * and try again */
-    for (try = 0; ; try++) {
+    for (attempt = 0; ; attempt++) {
         va_start(arg, fmt);
         /* Append the new formatted string */
         /* fmt_len is the length of the string required, excluding the
@@ -238,7 +238,7 @@ void strbuf_append_fmt_retry(strbuf_t *s, const char *fmt, ...)
 
         if (fmt_len <= empty_len)
             break;  /* SUCCESS */
-        if (try > 0)
+        if (attempt > 0)
             die("BUG: length of formatted string changed");
 
         strbuf_resize(s, s->length + fmt_len);

--- a/strbuf.h
+++ b/strbuf.h
@@ -48,6 +48,10 @@ typedef struct {
 #define STRBUF_DEFAULT_INCREMENT -2
 #endif
 
+#ifdef _MSC_VER
+#define inline 
+#endif
+
 /* Initialise */
 extern strbuf_t *strbuf_new(int len);
 extern void strbuf_init(strbuf_t *s, int len);


### PR DESCRIPTION
An option is added to encode empty Lua tables to arrays. The option is _encode_empty_table_as_array_ and is set like this:

``` lua
   cjson.encode_empty_table_as_array("on")
   assert( cjson.encode{} == "[]" )
```

By default, the option is off.

This is the only commit that needs to be taken into consideration:
https://github.com/ignacio/lua-cjson/commit/a6f950fa3b1f5d2b50a405cca5a74000dcf3dd16

The others correspond to other stuff.
