### PR TITLE
Work around MSVC's C99 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,13 @@ else()
     set(_lua_module_dir "${_lua_lib_dir}/lua/5.1")
 endif()
 
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-Dinline=__inline)
+    add_definitions(-Dsnprintf=_snprintf)
+    add_definitions(-Dstrncasecmp=_strnicmp)
+endif()
+
 add_library(cjson MODULE lua_cjson.c strbuf.c ${FPCONV_SOURCES})
 set_target_properties(cjson PROPERTIES PREFIX "")
 target_link_libraries(cjson ${_MODULE_LINK})

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -54,6 +54,12 @@
 #define CJSON_VERSION   "2.1devel"
 #endif
 
+#ifdef _MSC_VER
+#define CJSON_EXPORT    __declspec(dllexport)
+#else
+#define CJSON_EXPORT    extern
+#endif
+
 /* Workaround for Solaris platforms missing isinf() */
 #if !defined(isinf) && (defined(USE_INTERNAL_ISINF) || defined(MISSING_ISINF))
 #define isinf(x) (!isnan(x) && isnan((x) - (x)))
@@ -1407,7 +1413,7 @@ static int lua_cjson_safe_new(lua_State *l)
     return 1;
 }
 
-int luaopen_cjson(lua_State *l)
+CJSON_EXPORT int luaopen_cjson(lua_State *l)
 {
     lua_cjson_new(l);
 
@@ -1421,7 +1427,7 @@ int luaopen_cjson(lua_State *l)
     return 1;
 }
 
-int luaopen_cjson_safe(lua_State *l)
+CJSON_EXPORT int luaopen_cjson_safe(lua_State *l)
 {
     lua_cjson_safe_new(l);
 


### PR DESCRIPTION
1, `inline` keyword is only available in C++, define to `__inline` instead.
2, Visual C++ doesn't supply `snprintf` and  `strncasecmp `, define to `_snprintf` and `_strnicmp` instead.
3, define `_CRT_SECURE_NO_WARNINGS` to disable deprecation warnings.
