### PR TITLE
Support lua 5.3 integer representation

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -594,7 +594,7 @@ static void json_append_number(lua_State *l, json_config_t *cfg,
     if (lua_isinteger(l, lindex)) {
         lua_Integer num = lua_tointeger(l, lindex);
         strbuf_ensure_empty_length(json, FPCONV_G_FMT_BUFSIZE); /* max length of int64 is 19 */
-        len = lua_integer2str(strbuf_empty_ptr(json), num);
+        len = sprintf(strbuf_empty_ptr(json), LUA_INTEGER_FMT, num);
         strbuf_extend_length(json, len);
         return;
     }

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -589,8 +589,17 @@ static void json_append_array(lua_State *l, json_config_t *cfg, int current_dept
 static void json_append_number(lua_State *l, json_config_t *cfg,
                                strbuf_t *json, int lindex)
 {
-    double num = lua_tonumber(l, lindex);
     int len;
+#if LUA_VERSION_NUM >= 503
+    if (lua_isinteger(l, lindex)) {
+        lua_Integer num = lua_tointeger(l, lindex);
+        strbuf_ensure_empty_length(json, FPCONV_G_FMT_BUFSIZE); /* max length of int64 is 19 */
+        len = lua_integer2str(strbuf_empty_ptr(json), num);
+        strbuf_extend_length(json, len);
+        return;
+    }
+#endif
+    double num = lua_tonumber(l, lindex);
 
     if (cfg->encode_invalid_numbers == 0) {
         /* Prevent encoding invalid numbers */


### PR DESCRIPTION
lua-cjson would decode the integer to a float number in lua 5.3.
This patch use `lua_pushinteger` when the number is an integer.

It's also compatible with lua 5.1/5.2, because `lua_pushinteger` is not a new api.
