### PR TITLE
option to force to encode empty table to "[]"

### DIFF
--- a/tests/test.lua
+++ b/tests/test.lua
@@ -89,6 +89,9 @@ local NaN = math.huge * 0;
 
 local testdata = load_testdata()
 
+local empty_array = {}
+setmetatable(empty_array, json.as_array)
+
 local cjson_tests = {
     -- Test API variables
     { "Check module name, version",
@@ -212,6 +215,10 @@ local cjson_tests = {
       json.encode, { 10 }, true, { '10' } },
     { "Encode string",
       json.encode, { "hello" }, true, { '"hello"' } },
+    { "Encode empty table as array",
+      json.encode, { empty_array }, true, { '[]' } },
+    { "Encode empty table as table",
+      json.encode, { {} }, true, { '{}' } },
     { "Encode Lua function [throw error]",
       json.encode, { function () end },
       false, { "Cannot serialise function: type not supported" } },


### PR DESCRIPTION
Since lua-cjson use table index type to decide the result json type that a lua table is
encoded to, there is no way to encode empty lua table to a list in json.

This patch solves this problem by assigning a special meta-table to an
empty table to force it to be encoded to "[]" instead of "{}":

    local t = {}
    setmetatable(t,cjson.as_array)
    json.encode(t) -- > "[]"