### PR TITLE
Avoid escaping forward slash

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -164,7 +164,7 @@ static const char *char2escape[256] = {
     "\\u0018", "\\u0019", "\\u001a", "\\u001b",
     "\\u001c", "\\u001d", "\\u001e", "\\u001f",
     NULL, NULL, "\\\"", NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, "\\/",
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,

--- a/manual.adoc
+++ b/manual.adoc
@@ -364,7 +364,6 @@ Lua CJSON will escape the following characters within each UTF-8 string:
 
 - Control characters (ASCII 0 - 31)
 - Double quote (ASCII 34)
-- Forward slash (ASCII 47)
 - Blackslash (ASCII 92)
 - Delete (ASCII 127)
 

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -413,6 +413,10 @@ local cjson_tests = {
     { "Decode (safe) error generation after new()",
       function(...) return json_safe.new().decode(...) end, { "Oops" },
       true, { nil, "Expected value but found invalid token at character 1" } },
+
+    { "Encode forward slash unescaped",
+      json.encode, {{ content={booths={custom0="https://t.co/a/b/c"}} }},
+      true, { '{"content":{"booths":{"custom0":"https://t.co/a/b/c"}}}' } },
 }
 
 print(("==> Testing Lua CJSON version %s\n"):format(json._VERSION))


### PR DESCRIPTION
Forward slash may be escaped according to the JSON specification. In practice, escaped forward slash is not interpreted properly by most applications that consume JSON. For instance, it's very common to embed http(s) link in the JSON file. Using cjson will breaks these applications. 
So please consider accept this pull request to make cjson a good fit for these applications.

Thanks in advance!
