### PR TITLE
Fix missing strncasecmp on Windows

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -46,6 +46,10 @@
 #include "strbuf.h"
 #include "fpconv.h"
 
+#if defined(_WIN32) || defined(_WIN64)
+#define strncasecmp _strnicmp
+#endif
+
 #ifndef CJSON_MODNAME
 #define CJSON_MODNAME   "cjson"
 #endif


### PR DESCRIPTION
Macro `strncasecmp` to `_strnicmp` on Windows, as the lack of `strncasecmp` in MSVC was preventing compilation. Unsure if this will affect MinGW users, as I'd have to set up the entire toolchain and set up Lua and LuaRocks to use it in order to check.