### PR TITLE
docs: fix simple typo, ininity -> infinity

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -422,7 +422,7 @@ static void json_create_config(lua_State *l)
 
     /* Update characters that require further processing */
     cfg->ch2token['f'] = T_UNKNOWN;     /* false? */
-    cfg->ch2token['i'] = T_UNKNOWN;     /* inf, ininity? */
+    cfg->ch2token['i'] = T_UNKNOWN;     /* inf, infinity? */
     cfg->ch2token['I'] = T_UNKNOWN;
     cfg->ch2token['n'] = T_UNKNOWN;     /* null, nan? */
     cfg->ch2token['N'] = T_UNKNOWN;


### PR DESCRIPTION
There is a small typo in lua_cjson.c.

Should read `infinity` rather than `ininity`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md