### PR TITLE
Provide a global option to enable/disable escaping of forward slashes

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -447,6 +447,14 @@ static void json_create_config(lua_State *l)
     cfg->escape2char['u'] = 'u';          /* Unicode parsing required */
 }
 
+/* Whether to escape forward slashes */
+static int json_escape_forward_slash(lua_State *l)
+{
+    lua_Integer escape_forward_slash = luaL_checkinteger(l, 1);
+    char2escape['/'] = escape_forward_slash ? "\\/" : NULL;
+    return 0;
+}
+
 /* ===== ENCODING ===== */
 
 static void json_encode_exception(lua_State *l, json_config_t *cfg, strbuf_t *json, int lindex,
@@ -1365,6 +1373,7 @@ static int lua_cjson_new(lua_State *l)
         { "encode_keep_buffer", json_cfg_encode_keep_buffer },
         { "encode_invalid_numbers", json_cfg_encode_invalid_numbers },
         { "decode_invalid_numbers", json_cfg_decode_invalid_numbers },
+        { "escape_forward_slash", json_escape_forward_slash },
         { "new", lua_cjson_new },
         { NULL, NULL }
     };


### PR DESCRIPTION
Many people are discussing how to solve the forward slash escaping problem, which shows that this is a common demand.

For example:
https://github.com/mpx/lua-cjson/pull/57
https://github.com/mpx/lua-cjson/issues/66

Existing solutions are changed from escaping to non-escaping, losing flexibility.

I think it would be better to add a switch to control it, but if it is placed in cfg, when traversing characters for escaping, an additional `if` judgment is required each time. It is better to modify the `char2escape` table directly, which has better performance.

But this brings a new problem, that is, different cjson objects created by `cjson.new()` will share this setting. I don't think the problem is big. Most people either turn on or off escaping. It is unlikely that different cjson objects in the same process have two requirements for escaping. 

This option(`escape_forward_slash`) can be regarded as a global option.

