### PR TITLE
perf: using nil replace userdata: (nil) while decoding string which c…

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1253,9 +1253,7 @@ static void json_process_value(lua_State *l, json_parse_t *json,
         json_parse_array_context(l, json);
         break;;
     case T_NULL:
-        /* In Lua, setting "t[k] = nil" will delete k from the table.
-         * Hence a NULL pointer lightuserdata object is used instead */
-        lua_pushlightuserdata(l, NULL);
+        lua_pushnil(l);
         break;;
     default:
         json_throw_parse_error(l, json, "value", token);


### PR DESCRIPTION
…ontains null

A null pointer substitution is currently used while parsing a string contains `null`, which is not expected by those who are unaware of this rule. Is it better to keep the semantics as they are?
~~~

/* In Lua, setting "t[k] = nil" will delete k from the table.
 * Hence a NULL pointer lightuserdata object is used instead */
// lua_pushlightuserdata(l, NULL);
~~~
The changed test code and output are shown below, perhaps more as expected

~~~
local tbl = {1, nil, "hello world"}
local encodeStr = json.encode(tbl)
print("encodeStr", encodeStr)
local decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end
encodeStr = json.encode(decodeTbl)
print("encodeStr", encodeStr)
decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end

local tbl = {a = "a", b = "b", c = "c"}
encodeStr = json.encode(tbl)
print("encodeStr", encodeStr)
decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end

encodeStr = json.encode(decodeTbl)
print("encodeStr", encodeStr)
decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end

输出：
encodeStr	[1,null,"hello world"]
1	1
3	hello world
encodeStr	[1,null,"hello world"]
1	1
3	hello world
encodeStr	{"c":"c","b":"b","a":"a"}
c	c
b	b
a	a
encodeStr	{"c":"c","b":"b","a":"a"}
c	c
b	b
a	a
~~~