### PR TITLE
Work around newer CMake and MSVC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@
 #       Unix: export LUA_DIR=/home/user/pkg
 #       Windows: set LUA_DIR=c:\lua51
 
+cmake_minimum_required(VERSION 2.6...3.5)
 project(lua-cjson C)
-cmake_minimum_required(VERSION 2.6)
 
 option(USE_INTERNAL_FPCONV "Use internal strtod() / g_fmt() code for performance")
 option(MULTIPLE_THREADS "Support multi-threaded apps with internal fpconv - recommended" ON)
@@ -71,7 +71,9 @@ endif()
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_definitions(-Dinline=__inline)
-    add_definitions(-Dsnprintf=_snprintf)
+    if (MSVC_VERSION LESS 1900)
+        add_definitions(-Dsnprintf=_snprintf)
+    endif()
     add_definitions(-Dstrncasecmp=_strnicmp)
 endif()
 


### PR DESCRIPTION
1. Eliminate two cmake warnings.

```
CMake Warning (dev) at CMakeLists.txt:6 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.19045.
CMake Deprecation Warning at CMakeLists.txt:7 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

There are two CMake warnings when using newer CMake(above 3.5) and the wrong order of `cmake_minimum_required`(should be the first line)

In order to maintain compatibility with lower versions of CMake and eliminate warnings, the order of CMake statements was changed and the `<min>...<max>` form was used to set the version range.

2. Work around newer MSVC support

In VS 2015 and newer, the `snprintf` is supported, so there is no need to add define by `-Dsnprintf=_snprintf`, which can be found in [here](https://learn.microsoft.com/en-us/cpp/porting/visual-cpp-change-history-2003-2015?view=msvc-170#VC_2015)

The corresponding `MSVC_VERSION` for `MSVC` can be found [here](https://learn.microsoft.com/en-us/cpp/overview/compiler-versions). Although i have not tested it on lower versions of Visual Studio, it should work.

I tested in MSVC 2019 and 2022 with CMake 3.29.3.