### PR TITLE
Fix pointer truncation warning

### DIFF
--- a/strbuf.c
+++ b/strbuf.c
@@ -26,6 +26,8 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "strbuf.h"
 
@@ -94,8 +96,8 @@ void strbuf_set_increment(strbuf_t *s, int increment)
 static inline void debug_stats(strbuf_t *s)
 {
     if (s->debug) {
-        fprintf(stderr, "strbuf(%lx) reallocs: %d, length: %d, size: %d\n",
-                (long)s, s->reallocs, s->length, s->size);
+        fprintf(stderr, "strbuf(%" PRIxPTR ") reallocs: %d, length: %d, size: %d\n",
+                (uintptr_t)s, s->reallocs, s->length, s->size);
     }
 }
 
@@ -168,8 +170,8 @@ void strbuf_resize(strbuf_t *s, int len)
     newsize = calculate_new_size(s, len);
 
     if (s->debug > 1) {
-        fprintf(stderr, "strbuf(%lx) resize: %d => %d\n",
-                (long)s, s->size, newsize);
+        fprintf(stderr, "strbuf(%" PRIxPTR ") resize: %d => %d\n",
+                (uintptr_t)s, s->size, newsize);
     }
 
     s->size = newsize;


### PR DESCRIPTION
Fixes warning 'type cast': pointer truncation from 'strbuf_t *' to 'long'